### PR TITLE
issue #920 - bash interpolation vulnerability

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -436,17 +436,17 @@ function clock_prompt {
 # backwards-compatibility
 function git_prompt_info {
   git_prompt_vars
-  echo -e "$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
+  echo -e "${SCM_PREFIX}${SCM_BRANCH}${SCM_STATE}${SCM_SUFFIX}"
 }
 
 function svn_prompt_info {
   svn_prompt_vars
-  echo -e "$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
+  echo -e "${SCM_PREFIX}${SCM_BRANCH}${SCM_STATE}${SCM_SUFFIX}"
 }
 
 function hg_prompt_info() {
   hg_prompt_vars
-  echo -e "$SCM_PREFIX$SCM_BRANCH:${SCM_CHANGE#*:}$SCM_STATE$SCM_SUFFIX"
+  echo -e "${SCM_PREFIX}${SCM_BRANCH}:${SCM_CHANGE#*:}${SCM_STATE}${SCM_SUFFIX}"
 }
 
 function scm_char {

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -123,6 +123,15 @@ function scm_prompt_info_common {
   [[ ${SCM} == ${SCM_SVN} ]] && svn_prompt_info && return
 }
 
+# This is added to address bash shell interpolation vulnerability described
+# here: https://github.com/njhartwell/pw3nage
+function git_clean_branch {
+  local unsafe_ref=$(command git symbolic-ref -q HEAD 2> /dev/null)
+  local stripped_ref=${unsafe_ref##refs/heads/}
+  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/]/-}
+  echo $clean_ref
+}
+
 function git_prompt_minimal_info {
   local ref
   local status
@@ -131,9 +140,9 @@ function git_prompt_minimal_info {
 
   if [[ "$(command git config --get bash-it.hide-status)" != "1" ]]; then
     # Get the branch reference
-    ref=$(command git symbolic-ref -q HEAD 2> /dev/null) || \
+    ref=$(git_clean_branch) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
-    SCM_BRANCH=${SCM_THEME_BRANCH_PREFIX}${ref#refs/heads/}
+    SCM_BRANCH=${SCM_THEME_BRANCH_PREFIX}${ref}
 
     # Get the status
     [[ "${SCM_GIT_IGNORE_UNTRACKED}" = "true" ]] && git_status_flags+='-untracked-files=no'
@@ -207,10 +216,11 @@ function git_prompt_vars {
 
   SCM_CHANGE=$(git rev-parse --short HEAD 2>/dev/null)
 
-  local ref=$(git symbolic-ref -q HEAD 2> /dev/null)
+  local ref=$(git_clean_branch)
+
   if [[ -n "$ref" ]]; then
-    SCM_BRANCH=${SCM_THEME_BRANCH_PREFIX}${ref#refs/heads/}
-    local tracking_info="$(grep "${SCM_BRANCH}\.\.\." <<< "${status}")"
+    SCM_BRANCH="${SCM_THEME_BRANCH_PREFIX}${ref}"
+    local tracking_info="$(grep -- "${SCM_BRANCH}\.\.\." <<< "${status}")"
     if [[ -n "${tracking_info}" ]]; then
       [[ "${tracking_info}" =~ .+\[gone\]$ ]] && local branch_gone="true"
       tracking_info=${tracking_info#\#\# ${SCM_BRANCH}...}


### PR DESCRIPTION
Addresses issue here: https://github.com/njhartwell/pw3nage

We use a whitelist to `[a-zA-Z0-9\/-]` and replace malicious branch names.

```
 2017-04-19 18:39:40 ⌚  curtis in ~/workspace/source/mine/pw3nage
± |---/pw3n- ✓| →
```

```
2017-04-19 19:53:56 ⌚  curtis in ~/workspace/source/mine/bash-it
± |denmat-issues-920 U:1 ?:3 ✗| →
```